### PR TITLE
Change shape of GetByWeekReponse to include dates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "cSpell.enableFiletypes": [
+        "c4"
+    ],
+    "cSpell.words": [
+        "appsettings",
+        "Npgsql"
+    ]
+}

--- a/OfficeAttendance.Application/DTOs/Attendance/GetByWeekResponse.cs
+++ b/OfficeAttendance.Application/DTOs/Attendance/GetByWeekResponse.cs
@@ -3,5 +3,5 @@
 namespace OfficeAttendance.Application.DTOs.Attendance;
 
 public class GetByWeekResponse {
-    public IEnumerable<Employee> Employees { get; set; } = new List<Employee>();
+    public IEnumerable<AttendanceReport> AttendanceReport { get; set; } = [];
 }

--- a/OfficeAttendance.Application/UseCases/Attendance/GetAttendanceByWeekUseCase.cs
+++ b/OfficeAttendance.Application/UseCases/Attendance/GetAttendanceByWeekUseCase.cs
@@ -1,6 +1,7 @@
 ﻿using OfficeAttendance.Application.DTOs.Attendance;
 using OfficeAttendance.Core.Interfaces;
 using OfficeAttendance.Core.Exceptions.Attendance;
+using OfficeAttendance.Core.Entities;
 
 namespace OfficeAttendance.Application.UseCases.Attendance;
 public class GetAttendanceByWeekUseCase(IAttendanceRepository attendanceRepository) {
@@ -8,8 +9,8 @@ public class GetAttendanceByWeekUseCase(IAttendanceRepository attendanceReposito
         ct.ThrowIfCancellationRequested();
 
         try {
-            var attendanceRecords = await attendanceRepository.GetByWeek(ct);
-            return new GetByWeekResponse { Employees = attendanceRecords };
+            IEnumerable<AttendanceReport> attendanceRecords = await attendanceRepository.GetByWeek(ct);
+            return new GetByWeekResponse { AttendanceReport = attendanceRecords };
         }
         catch (Exception ex) {
             throw new AttendanceNotFoundException("Failed to get attendance by week", ex);

--- a/OfficeAttendance.Core/Entities/AttendanceReport.cs
+++ b/OfficeAttendance.Core/Entities/AttendanceReport.cs
@@ -1,0 +1,6 @@
+namespace OfficeAttendance.Core.Entities;
+
+public class AttendanceReport {
+    public DateOnly Date { get; set; }
+    public IEnumerable<Employee> Employees { get; set; } = [];
+}

--- a/OfficeAttendance.Core/Interfaces/IAttendanceRepository.cs
+++ b/OfficeAttendance.Core/Interfaces/IAttendanceRepository.cs
@@ -4,7 +4,7 @@ namespace OfficeAttendance.Core.Interfaces;
 
 public interface IAttendanceRepository {
     Task<IEnumerable<Employee>> GetByDay(DateOnly date, CancellationToken ct);
-    Task<IEnumerable<Employee>> GetByWeek(CancellationToken ct);
+    Task<IEnumerable<AttendanceReport>> GetByWeek(CancellationToken ct);
     Task<IEnumerable<Attendance>> GetByUserId(int id, CancellationToken ct);
     Task<Attendance> ConfirmAttendance(Attendance attendance, CancellationToken ct);
     Task<Attendance> DeleteAttendance(int id, CancellationToken ct);

--- a/OfficeAttendance.Tests/Application/Fakes/FakeAttendanceRepository.cs
+++ b/OfficeAttendance.Tests/Application/Fakes/FakeAttendanceRepository.cs
@@ -6,6 +6,7 @@ namespace OfficeAttendance.Tests.Application.Fakes {
     public class FakeAttendanceRepository : IAttendanceRepository {
         private const int defaultWeek = 1;
         private readonly Dictionary<object, List<Employee>> _attendance = [];
+        private readonly Dictionary<int, List<AttendanceReport>> _attendanceReport = [];
         public bool WasGetByWeekCalled { get; private set; } = false;
         public bool WasGetByDayCalled { get; private set; } = false;
         public bool ShouldThrowException { get; set; } = false;
@@ -15,7 +16,7 @@ namespace OfficeAttendance.Tests.Application.Fakes {
         public void SetAttendance(IEnumerable<Employee>? attendance, DateOnly key) => _attendance[key] = attendance?.ToList() ?? [];
 
 
-        public void SetAttendanceForWeek(IEnumerable<Employee> attendance, int week) => _attendance[week] = attendance?.ToList() ?? [];
+        public void SetAttendanceForWeek(IEnumerable<AttendanceReport> attendance, int week) => _attendanceReport[week] = attendance.ToList() ?? [];
 
         public void SetCurrentWeek(int week) => _currentWeek = week;
 
@@ -28,13 +29,13 @@ namespace OfficeAttendance.Tests.Application.Fakes {
             return Task.FromResult<IEnumerable<Employee>>(attendance ?? []);
         }
 
-        public Task<IEnumerable<Employee>> GetByWeek(CancellationToken cancellationToken) {
+        public Task<IEnumerable<AttendanceReport>> GetByWeek(CancellationToken cancellationToken) {
             WasGetByWeekCalled = true;
             if (ShouldThrowException) {
                 throw new AttendanceNotFoundException("Failed to get attendance by week");
             }
-            _attendance.TryGetValue(_currentWeek, out List<Employee>? attendance);
-            return Task.FromResult<IEnumerable<Employee>>(attendance ?? []);
+            _ = _attendanceReport.TryGetValue(_currentWeek, out List<AttendanceReport>? attendance);
+            return Task.FromResult<IEnumerable<AttendanceReport>>(attendance ?? []);
         }
 
         public Task<IEnumerable<Attendance>> GetByUserId(int id, CancellationToken ct) => throw new NotImplementedException();

--- a/OfficeAttendance.Tests/Application/UseCases/Attendance/GetAttendanceByWeekUseCaseTests.cs
+++ b/OfficeAttendance.Tests/Application/UseCases/Attendance/GetAttendanceByWeekUseCaseTests.cs
@@ -20,18 +20,25 @@ public class GetAttendanceByWeekUseCaseTests {
     [Fact]
     public async Task GetAttendanceByWeekUseCase_ShouldReturnAttendance_WhenValidRequestIsPassed() {
         // Arrange
-        var mockAttendance = new List<Employee>
+        var mockAttendance = new List<AttendanceReport>
         {
-            new Employee { Id = 1, FirstName = "Dante", LastName = "Alighieri" },
+            new() {
+                Date = new DateOnly(2024, 09, 2),
+                Employees =
+                [
+                    new() { Id = 1, FirstName = "Dante", LastName = "Alighieri" }
+                ]
+            },
         };
-        _attendanceRepository.SetAttendance(mockAttendance);
+
+        _attendanceRepository.SetAttendanceForWeek(mockAttendance, 1);
 
         // Act
         GetByWeekResponse result = await _useCase.ExecuteAsync(_cancellationToken);
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal(mockAttendance.Count, result.Employees.Count());
+        Assert.Equal(mockAttendance.Count, result.AttendanceReport.Count());
         Assert.True(_attendanceRepository.WasGetByWeekCalled);
     }
 
@@ -45,7 +52,7 @@ public class GetAttendanceByWeekUseCaseTests {
 
         // Assert
         Assert.NotNull(result);
-        Assert.Empty(result.Employees);
+        Assert.Empty(result.AttendanceReport);
         Assert.True(_attendanceRepository.WasGetByWeekCalled);
     }
 
@@ -79,14 +86,35 @@ public class GetAttendanceByWeekUseCaseTests {
     [Fact]
     public async Task GetAttendanceByWeekUseCase_ShouldReturnCorrectAttendance_WhenDifferentWeeksAreQueried() {
         // Arrange
-        var week1Attendance = new List<Employee>
+        var week1Attendance = new List<AttendanceReport>
         {
-            new() { Id = 1, FirstName = "Dante", LastName = "Alighieri" },
-            new() { Id = 2, FirstName = "Italo", LastName = "Calvino" },
+            new() {
+                Date = new DateOnly(2024, 09, 2),
+                Employees =
+                [
+                    new() { Id = 1, FirstName = "Dante", LastName = "Alighieri" },
+                    new() { Id = 2, FirstName = "Italo", LastName = "Calvino" }
+                ]
+            },
+            new() {
+                Date = new DateOnly(2024, 09, 4),
+                Employees =
+                [
+                    new() { Id = 3, FirstName = "Giovanni", LastName = "Boccaccio" },
+                    new() { Id = 4, FirstName = "Petrarch", LastName = "Francesco" }
+                ]
+            }
         };
-        var week2Attendance = new List<Employee>
+        
+        var week2Attendance = new List<AttendanceReport>
         {
-            new() { Id = 3, FirstName = "Julio", LastName = "Cortazar" },
+            new() {
+                Date = new DateOnly(2024, 09, 9),
+                Employees =
+                [
+                    new Employee { Id = 5, FirstName = "Julio", LastName = "Cortazar" }
+                ]
+            }
         };
 
         _attendanceRepository.SetAttendanceForWeek(week1Attendance, 1);
@@ -99,10 +127,10 @@ public class GetAttendanceByWeekUseCaseTests {
 
         // Assert
         Assert.NotNull(resultWeek1);
-        Assert.Equal(week1Attendance.Count(), resultWeek1.Employees.Count());
+        Assert.Equal(week1Attendance.Count, resultWeek1.AttendanceReport.Count());
 
         Assert.NotNull(resultWeek2);
-        Assert.Equal(week2Attendance.Count(), resultWeek2.Employees.Count());
+        Assert.Equal(week2Attendance.Count, resultWeek2.AttendanceReport.Count());
     }
 
     [Fact]
@@ -115,7 +143,7 @@ public class GetAttendanceByWeekUseCaseTests {
 
         // Assert
         Assert.NotNull(result);
-        Assert.Empty(result.Employees);
+        Assert.Empty(result.AttendanceReport);
         Assert.True(_attendanceRepository.WasGetByWeekCalled);
     }
 }

--- a/OfficeAttendance.WebAPI/Endpoints/Attendance/GetAttendanceByDayEndpoint.cs
+++ b/OfficeAttendance.WebAPI/Endpoints/Attendance/GetAttendanceByDayEndpoint.cs
@@ -2,7 +2,7 @@
 using OfficeAttendance.Application.DTOs.Attendance;
 using OfficeAttendance.Application.UseCases.Attendance;
 
-namespace OfficeAttendance.WebAPI.Endpoints.Employee.Attendance;
+namespace OfficeAttendance.WebAPI.Endpoints.Attendance;
 
 public class GetAttendanceByDayEndpoint(GetAttendanceByDayUseCase getAttendanceByDayUseCase) : Endpoint<GetByDayRequest, GetByDayResponse> {
     public override void Configure() {
@@ -11,7 +11,7 @@ public class GetAttendanceByDayEndpoint(GetAttendanceByDayUseCase getAttendanceB
     }
 
     public override async Task HandleAsync(GetByDayRequest request, CancellationToken ct) {
-        var response = await getAttendanceByDayUseCase.ExecuteAsync(request, ct);
+        GetByDayResponse response = await getAttendanceByDayUseCase.ExecuteAsync(request, ct);
         await SendAsync(response, cancellation: ct);
     }
 }

--- a/OfficeAttendance.WebAPI/Endpoints/Attendance/GetAttendanceByWeekEndpoint.cs
+++ b/OfficeAttendance.WebAPI/Endpoints/Attendance/GetAttendanceByWeekEndpoint.cs
@@ -2,7 +2,7 @@
 using OfficeAttendance.Application.DTOs.Attendance;
 using OfficeAttendance.Application.UseCases.Attendance;
 
-namespace OfficeAttendance.WebAPI.Endpoints.Employee.Attendance;
+namespace OfficeAttendance.WebAPI.Endpoints.Attendance;
 
 public class GetAttendanceByWeekEndpoint(GetAttendanceByWeekUseCase getAttendanceByWeekUseCase) : EndpointWithoutRequest<GetByWeekResponse> {
     public override void Configure() {
@@ -11,7 +11,7 @@ public class GetAttendanceByWeekEndpoint(GetAttendanceByWeekUseCase getAttendanc
     }
 
     public override async Task HandleAsync(CancellationToken ct) {
-        var response = await getAttendanceByWeekUseCase.ExecuteAsync(ct);
+        GetByWeekResponse response = await getAttendanceByWeekUseCase.ExecuteAsync(ct);
         await SendAsync(response, cancellation: ct);
     }
 }


### PR DESCRIPTION
## Change shape of GetByWeekReponse to include dates

### Why:
This PR introduces several changes related to attendance reporting by week, improving the structure of the codebase, and aligning the model more closely with expected data output. It also includes renaming of certain endpoint files to ensure better alignment with functionality, configuration updates, and minor syntax enhancements.

### Changes:
1. **New Files:**
   - `.vscode/settings.json`: Adds spell-check configurations for specific file types and terms relevant to the project.
   - `OfficeAttendance.Core/Entities/AttendanceReport.cs`: Defines a new entity `AttendanceReport` to better model weekly attendance data.

2. **Modified Files:**
   - `OfficeAttendance.Application/DTOs/Attendance/GetByWeekResponse.cs`: Refactor the `Employees` field to `AttendanceReport`, which now holds grouped attendance data by date.
   - `OfficeAttendance.Application/UseCases/Attendance/GetAttendanceByWeekUseCase.cs`: Updated to return a list of `AttendanceReport` entities instead of `Employee` lists, reflecting the new data structure.
   - `OfficeAttendance.Core/Interfaces/IAttendanceRepository.cs`: Updated the `GetByWeek` method to return `AttendanceReport` entities.
   - `OfficeAttendance.Infrastructure/Data/Repositories/AttendanceRepository.cs`: Refactored to group attendance records by date, creating `AttendanceReport` objects.
   - `OfficeAttendance.Tests/Application/Fakes/FakeAttendanceRepository.cs`: Adjusted test fake repository to handle `AttendanceReport` instead of `Employee` lists.
   - `OfficeAttendance.Tests/Application/UseCases/Attendance/GetAttendanceByWeekUseCaseTests.cs`: Updated test cases to work with the `AttendanceReport` entity and test the new functionality.
   - Renamed files for better alignment with responsibilities:
     - `OfficeAttendance.WebAPI/Endpoints/Employee/Attendance/GetAttendanceByDayEndpoint.cs` → `OfficeAttendance.WebAPI/Endpoints/Attendance/GetAttendanceByDayEndpoint.cs`
     - `OfficeAttendance.WebAPI/Endpoints/Employee/Attendance/GetAttendanceByWeekEndpoint.cs` → `OfficeAttendance.WebAPI/Endpoints/Attendance/GetAttendanceByWeekEndpoint.cs`

3. **Other Changes:**
   - `appsettings.json` and `appsettings.Development.json`: Updated configurations to include CORS settings for localhost.

### Code Changes:
- **`GetByWeekResponse.cs`**:
  ```csharp
  public IEnumerable<AttendanceReport> AttendanceReport { get; set; } = [];
  ```
  Changed to store a list of `AttendanceReport` instead of `Employee`.

- **`GetAttendanceByWeekUseCase.cs`**:
  ```csharp
  return new GetByWeekResponse { AttendanceReport = attendanceRecords };
  ```
  Now returns `AttendanceReport` instead of `Employee`.

- **`AttendanceRepository.cs`**:
  ```csharp
  var attendanceReport = attendanceRecords
      .GroupBy(a => a.Date)
      .Select(g => new AttendanceReport {
          Date = g.Key,
          Employees = g.Select(a => employees.First(e => e.Id == a.EmployeeId)).ToList()
      }).ToList();
  ```

### Reason for Changes:
- The primary motivation behind these changes was to improve the structure of weekly attendance reporting by creating a dedicated `AttendanceReport` entity. This groups employees by the specific date, providing a more organised data structure and reducing ambiguity.
- The renaming of files and namespaces enhances clarity, making it easier for future contributors to navigate the codebase.
- The adjustments to the tests ensure that the new entity is correctly validated and behaves as expected.

### Impact of Changes:
- These changes will improve the clarity of the attendance report output by organising data more effectively. The structure now groups employees under their respective attendance dates, making the data more useful for reporting purposes.
- The renaming of endpoint files and namespaces improves the clarity of the project structure without impacting the functionality of existing endpoints.

### Test Plan:
- Updated existing unit tests for `GetAttendanceByWeekUseCase` to account for the `AttendanceReport` entity. 
- Verified that all tests pass successfully, ensuring that weekly attendance reporting remains functional after the changes.